### PR TITLE
Update msg parsing to not use eval

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -7,3 +7,4 @@
 - Johannes Köster (@johanneskoester)
 - Georgios Ntalaperas (@gntalaperas)
 - Dimitrios Rekoumis (@drekoumis)
+- Vanessa Sochat (@vsoch)

--- a/panoptes/server_utilities/db_queries.py
+++ b/panoptes/server_utilities/db_queries.py
@@ -1,6 +1,7 @@
 from panoptes.database import db_session
 from panoptes.models import Workflows, WorkflowMessages, WorkflowJobs
 
+import json
 
 def get_db_workflows():
     return Workflows.query.all()
@@ -31,7 +32,9 @@ def get_db_table_is_empty(table_name):
 
 
 def maintain_jobs(msg, wf_id):
-    msg_json = eval(msg)
+
+    # The message should be a json dump
+    msg_json = json.loads(msg)
 
     if "jobid" in msg_json.keys():
         if msg_json["level"] == 'job_info':


### PR DESCRIPTION
This is a quick PR to update message parsing to not use eval. As we discussed in https://github.com/snakemake/snakemake/pull/819#issuecomment-751854197, we want to update snakemake to properly parse a dumped json (from a dict) instead of using repr() and then we can use json.loads() on the server here. 