### PR TITLE
convert_unicode no longer supported by db driver

### DIFF
--- a/panoptes/database.py
+++ b/panoptes/database.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-engine = create_engine('sqlite:///.panoptes.db?check_same_thread=False', convert_unicode=True)
+engine = create_engine('sqlite:///.panoptes.db?check_same_thread=False')
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,
                                          bind=engine))


### PR DESCRIPTION
It seems that sqlalchemy's sqlite3 driver no longer supports `convert_unicode` as an option.

Resolves issue #156 and allows panoptes to run with an up-to-date sqlalchemy.