### PR TITLE
README: bump container image pins to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Requirements:
 
 Pull image that is automatically built from bioconda. You can find the latest tag in the following url: https://quay.io/repository/biocontainers/panoptes-ui?tab=tags. For example:
 ```
-docker pull quay.io/biocontainers/panoptes-ui:0.2.3--pyh7cba7a3_0
+docker pull quay.io/biocontainers/panoptes-ui:1.0.0--pyhdfd78af_0
 ```
 
 Then run the container with:
@@ -139,12 +139,12 @@ docker-compose down
 You can also deploy the server with singularity. To do so pull the image with singularity. For example:
 
 ```bash
-singularity pull docker://quay.io/biocontainers/panoptes-ui:0.2.3--pyh7cba7a3_0
+singularity pull docker://quay.io/biocontainers/panoptes-ui:1.0.0--pyhdfd78af_0
 ```
 
 And then we can start the server by running:
 ```bash
-singularity exec panoptes-ui:0.2.3--pyh7cba7a3_0
+singularity exec panoptes-ui:1.0.0--pyhdfd78af_0
 ```
 
 # Run an example workflow


### PR DESCRIPTION
## Summary
- `panoptes-ui` 1.0.0 is now published on bioconda (bioconda/bioconda-recipes#65730 merged) and the biocontainer is built on quay.
- Update the Docker pull, Singularity pull, and Singularity exec examples from the old `0.2.3--pyh7cba7a3_0` to `1.0.0--pyhdfd78af_0`.

## Test plan
- [x] Verified `quay.io/biocontainers/panoptes-ui:1.0.0--pyhdfd78af_0` exists (quay API returns 200).
- [ ] Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)