### PR TITLE
Reuse a workflow by name on /create_workflow (1.1.0)

### DIFF
--- a/panoptes/app.py
+++ b/panoptes/app.py
@@ -11,7 +11,7 @@ from panoptes.database import init_db, db_session
 from panoptes.models import Workflows
 from panoptes.routes import *
 from panoptes.schema_forms import SnakemakeUpdateForm
-from panoptes.server_utilities.db_queries import maintain_jobs
+from panoptes.server_utilities.db_queries import maintain_jobs, get_db_workflow_by_name, reset_db_workflow
 
 app = Flask(__name__, template_folder="static/src/")
 app.config['TEMPLATES_AUTO_RELOAD'] = True
@@ -103,7 +103,15 @@ def get_job_status(wf_id, job_id):
 @app.route('/create_workflow', methods=['GET'])
 def create_workflow():
     try:
-        w = Workflows(str(uuid.uuid4()), "Running")
+        name = request.args.get('name')
+        if name:
+            # Reuse an existing workflow with this name (a re-run), resetting it
+            # so the new run starts from a clean state under the same id.
+            existing = get_db_workflow_by_name(name)
+            if existing is not None:
+                reset_db_workflow(existing.id)
+                return existing.get_workflow()
+        w = Workflows(name or str(uuid.uuid4()), "Running")
         db_session.add(w)
         db_session.commit()
 

--- a/panoptes/models.py
+++ b/panoptes/models.py
@@ -62,6 +62,13 @@ class Workflows(Base):
         self.done = 1
         self.status = 'No Execution'
 
+    def reset(self):
+        self.status = 'Running'
+        self.done = 0
+        self.total = 1
+        self.started_at = datetime.now()
+        self.completed_at = None
+
 
 class WorkflowMessages(Base):
     __tablename__ = 'workflow_messages'

--- a/panoptes/server_utilities/db_queries.py
+++ b/panoptes/server_utilities/db_queries.py
@@ -32,6 +32,10 @@ def get_db_workflows_by_status(workflow_id):
     return (db_session.query(Workflows.status).filter(Workflows.id == workflow_id).first())[0]
 
 
+def get_db_workflow_by_name(name):
+    return Workflows.query.filter(Workflows.name == name).first()
+
+
 def get_db_table_is_empty(table_name):
     if(table_name == 'User'):
         result = db_session.query(User.id).all()
@@ -174,6 +178,25 @@ def delete_db_wf(workflow_id):
         return True
     except:
         return False
+
+
+def reset_db_workflow(workflow_id):
+    """Clear a workflow's jobs/messages and return it to a fresh Running state,
+    so a re-run that reuses the same name starts clean instead of stacking the
+    previous run's rows."""
+    try:
+        db_session.query(WorkflowMessages).filter(
+            WorkflowMessages.wf_id == workflow_id).delete()
+        db_session.query(WorkflowJobs).filter(
+            WorkflowJobs.wf_id == workflow_id).delete()
+        wf = Workflows.query.filter(Workflows.id == workflow_id).first()
+        if wf is not None:
+            wf.reset()
+        db_session.commit()
+        return wf
+    except Exception:
+        db_session.rollback()
+        return None
 
 
 def delete_whole_db():

--- a/panoptes/tests/server_test.py
+++ b/panoptes/tests/server_test.py
@@ -63,6 +63,37 @@ def test_create_workflow_returns_id_and_uuid_name(client):
     assert payload["jobs_total"] == 1
 
 
+def test_create_workflow_with_name_uses_it(client):
+    payload = client.get("/create_workflow?name=my-run").get_json()
+    assert payload["name"] == "my-run"
+    assert payload["status"] == "Running"
+
+
+def test_create_workflow_same_name_reuses_the_workflow(client):
+    first = client.get("/create_workflow?name=nightly").get_json()
+    second = client.get("/create_workflow?name=nightly").get_json()
+    assert first["id"] == second["id"]
+    # Only one workflow row should exist for that name.
+    assert client.get("/api/workflows").get_json()["count"] == 1
+
+
+def test_create_workflow_name_reuse_resets_previous_run(client):
+    wf_id = client.get("/create_workflow?name=cohort").get_json()["id"]
+    _post_event(client, wf_id, {
+        "level": "job_info", "jobid": 1, "name": "step",
+        "input": [], "output": [],
+    })
+    _post_event(client, wf_id, {"level": "progress", "done": 2, "total": 5})
+    assert client.get(f"/api/workflow/{wf_id}/jobs").get_json()["count"] == 1
+
+    # Re-running with the same name reuses the id but clears the prior run.
+    reused = client.get("/create_workflow?name=cohort").get_json()
+    assert reused["id"] == wf_id
+    assert reused["status"] == "Running"
+    assert reused["jobs_done"] == 0
+    assert client.get(f"/api/workflow/{wf_id}/jobs").get_json()["count"] == 0
+
+
 # --------------------------------------------------------------------------- #
 # Ingestion: same payloads the Snakemake 9 plugin emits
 # --------------------------------------------------------------------------- #

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (Path(__file__).parent / "README.md").read_text(encoding="utf
 
 setuptools.setup(
     name='panoptes-ui',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/panoptes-organization/panoptes',
     license='MIT',
     author='panoptes-organization',


### PR DESCRIPTION
## Summary
Adds an optional `name` parameter to `GET /create_workflow`:
- If a workflow with that name already exists, it is **reused and reset** (jobs/messages cleared, counters returned to a fresh `Running` state) so a re-run lands on the same workflow id.
- Otherwise a workflow is created with that name.
- With no `name`, behaviour is unchanged (server-assigned uuid).

This is the **server half** of the logger-plugin `--logger-panoptes-name` feature (panoptes-organization/snakemake-logger-plugin-panoptes#3) and unblocks the long-standing request for a stable per-run id (#100). Bumps the package to **1.1.0**.

## Changes
- `app.py` — `/create_workflow` honours `?name=` (reuse+reset / create).
- `models.py` — `Workflows.reset()`.
- `server_utilities/db_queries.py` — `get_db_workflow_by_name()`, `reset_db_workflow()`.
- `tests/server_test.py` — 3 new tests (name used, same-name reuse, reuse resets the prior run).

## Sequencing
This should be **released before** the plugin's `--logger-panoptes-name` change so the flag has a server that understands it. Older plugins/clients are unaffected (they never send `name`).

## Test plan
- [x] `pytest panoptes/tests` — 19 passed, 18 skipped (legacy/e2e auto-skips).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)