### PR TITLE
CI: install Snakemake + plugin from PyPI in the example-workflow job

### DIFF
--- a/.github/workflows/python-package-conda-pip.yml
+++ b/.github/workflows/python-package-conda-pip.yml
@@ -47,9 +47,12 @@ jobs:
           channel-priority: strict
           python-version: '3.11'
 
-      - name: Install Snakemake 9 + plugin from bioconda
+      - name: Install Snakemake 9 + plugin from PyPI
+        # Miniconda stays available so snakemake's --use-conda can build the
+        # per-rule envs, but install snakemake and the plugin via pip so the
+        # test never waits on the bioconda channel catching up to a release.
         run: |
-          conda install -y -c conda-forge -c bioconda 'snakemake>=9' snakemake-logger-plugin-panoptes
+          pip install 'snakemake>=9' snakemake-logger-plugin-panoptes
 
       - name: Install panoptes from source
         run: pip install .


### PR DESCRIPTION
## Summary
The example-workflow CI job was installing `snakemake` and `snakemake-logger-plugin-panoptes` from bioconda, which makes the test wait for the bioconda channel to catch up after every release. Switch it back to a `pip` install from PyPI (which has new versions immediately).

Miniconda is still set up so `snakemake --use-conda` can build the per-rule envs for the example workflow — only the snakemake/plugin install changes.

## Why now
panoptes 1.1.0 and plugin 0.2.0 are (or will be) on PyPI well before bioconda; keeping the test on PyPI decouples CI from bioconda timing.

## Test plan
- [ ] example-workflow job green (drives `--logger panoptes` end-to-end against the PyPI-installed plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)