### PR TITLE
Accept workflow_id on /create_workflow (1.1.1)

### DIFF
--- a/panoptes/app.py
+++ b/panoptes/app.py
@@ -103,15 +103,17 @@ def get_job_status(wf_id, job_id):
 @app.route('/create_workflow', methods=['GET'])
 def create_workflow():
     try:
-        name = request.args.get('name')
-        if name:
-            # Reuse an existing workflow with this name (a re-run), resetting it
+        # Accept `workflow_id` (current) or the older `name` (back-compat with
+        # snakemake-logger-plugin-panoptes <= 0.2.1) as the stable identifier.
+        workflow_id = request.args.get('workflow_id') or request.args.get('name')
+        if workflow_id:
+            # Reuse an existing workflow with this id (a re-run), resetting it
             # so the new run starts from a clean state under the same id.
-            existing = get_db_workflow_by_name(name)
+            existing = get_db_workflow_by_name(workflow_id)
             if existing is not None:
                 reset_db_workflow(existing.id)
                 return existing.get_workflow()
-        w = Workflows(name or str(uuid.uuid4()), "Running")
+        w = Workflows(workflow_id or str(uuid.uuid4()), "Running")
         db_session.add(w)
         db_session.commit()
 

--- a/panoptes/tests/server_test.py
+++ b/panoptes/tests/server_test.py
@@ -63,22 +63,22 @@ def test_create_workflow_returns_id_and_uuid_name(client):
     assert payload["jobs_total"] == 1
 
 
-def test_create_workflow_with_name_uses_it(client):
-    payload = client.get("/create_workflow?name=my-run").get_json()
+def test_create_workflow_with_workflow_id_uses_it(client):
+    payload = client.get("/create_workflow?workflow_id=my-run").get_json()
     assert payload["name"] == "my-run"
     assert payload["status"] == "Running"
 
 
-def test_create_workflow_same_name_reuses_the_workflow(client):
-    first = client.get("/create_workflow?name=nightly").get_json()
-    second = client.get("/create_workflow?name=nightly").get_json()
+def test_create_workflow_same_workflow_id_reuses_the_workflow(client):
+    first = client.get("/create_workflow?workflow_id=nightly").get_json()
+    second = client.get("/create_workflow?workflow_id=nightly").get_json()
     assert first["id"] == second["id"]
-    # Only one workflow row should exist for that name.
+    # Only one workflow row should exist for that id.
     assert client.get("/api/workflows").get_json()["count"] == 1
 
 
-def test_create_workflow_name_reuse_resets_previous_run(client):
-    wf_id = client.get("/create_workflow?name=cohort").get_json()["id"]
+def test_create_workflow_workflow_id_reuse_resets_previous_run(client):
+    wf_id = client.get("/create_workflow?workflow_id=cohort").get_json()["id"]
     _post_event(client, wf_id, {
         "level": "job_info", "jobid": 1, "name": "step",
         "input": [], "output": [],
@@ -86,12 +86,21 @@ def test_create_workflow_name_reuse_resets_previous_run(client):
     _post_event(client, wf_id, {"level": "progress", "done": 2, "total": 5})
     assert client.get(f"/api/workflow/{wf_id}/jobs").get_json()["count"] == 1
 
-    # Re-running with the same name reuses the id but clears the prior run.
-    reused = client.get("/create_workflow?name=cohort").get_json()
+    # Re-running with the same workflow_id reuses the id but clears the prior run.
+    reused = client.get("/create_workflow?workflow_id=cohort").get_json()
     assert reused["id"] == wf_id
     assert reused["status"] == "Running"
     assert reused["jobs_done"] == 0
     assert client.get(f"/api/workflow/{wf_id}/jobs").get_json()["count"] == 0
+
+
+def test_create_workflow_legacy_name_param_is_still_accepted(client):
+    # Plugins <= 0.2.1 send ?name=; it must map to the same workflow as ?workflow_id=.
+    first = client.get("/create_workflow?name=legacy").get_json()
+    second = client.get("/create_workflow?workflow_id=legacy").get_json()
+    assert first["name"] == "legacy"
+    assert first["id"] == second["id"]
+    assert client.get("/api/workflows").get_json()["count"] == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (Path(__file__).parent / "README.md").read_text(encoding="utf
 
 setuptools.setup(
     name='panoptes-ui',
-    version='1.1.0',
+    version='1.1.1',
     url='https://github.com/panoptes-organization/panoptes',
     license='MIT',
     author='panoptes-organization',


### PR DESCRIPTION
## Summary
Renames the stable-identifier query parameter on `GET /create_workflow` from `name` to `workflow_id`, for naming consistency / backward compatibility with the previous convention.

- `workflow_id` is the canonical parameter.
- The older `name` is **still accepted** so `snakemake-logger-plugin-panoptes <= 0.2.1` (which sends `?name=`) keeps working; `workflow_id` wins if both are present.
- Reuse-and-reset behaviour is otherwise unchanged.

Closes #185. Coordinated with the plugin's hard rename to `--logger-panoptes-workflow-id` (snakemake-logger-plugin-panoptes#7). Bumps to **1.1.1**.

## Changes
- `app.py` — `request.args.get('workflow_id') or request.args.get('name')`.
- `tests/server_test.py` — tests switched to `workflow_id` + a back-compat test that legacy `name` maps to the same workflow.

## Test plan
- [x] `pytest panoptes/tests/server_test.py` — 19 passed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)