### PR TITLE
Fix duplicated jobs when a failed job is retried (1.1.2)

### DIFF
--- a/panoptes/models.py
+++ b/panoptes/models.py
@@ -133,6 +133,23 @@ class WorkflowJobs(Base):
     def __repr__(self):
         return self
 
+    def restart(self, msg, name, input, output, log, wildcards, is_checkpoint, shell_command=None):
+        """Reset an existing job back to a fresh Running state. Snakemake
+        re-emits a job_info event with the same jobid when a failed job is
+        re-submitted (e.g. via --retries), so we update the existing row
+        instead of inserting a duplicate."""
+        self.msg = msg
+        self.name = name
+        self.input = input
+        self.output = output
+        self.log = log
+        self.wildcards = wildcards
+        self.is_checkpoint = is_checkpoint
+        self.shell_command = shell_command
+        self.status = "Running"
+        self.started_at = datetime.now()
+        self.completed_at = None
+
     def get_job_json(self):
         return {"jobid": self.jobid,
                 "workflow_id": self.wf_id,

--- a/panoptes/server_utilities/db_queries.py
+++ b/panoptes/server_utilities/db_queries.py
@@ -60,18 +60,26 @@ def maintain_jobs(msg, wf_id):
 
     if "jobid" in msg_json and msg_json.get("jobid") is not None:
         if level == 'job_info':
-            job = WorkflowJobs(
-                msg_json['jobid'],
-                wf_id, msg_json.get('msg'),
+            job_fields = (
+                msg_json.get('msg'),
                 msg_json.get('name', ''),
                 repr(msg_json.get('input', [])),
                 repr(msg_json.get('output', [])),
                 repr(msg_json.get('log', [])),
                 repr(msg_json.get('wildcards', {})),
                 bool(msg_json.get('is_checkpoint', False)),
-                shell_command=msg_json.get('shellcmd'),
+                msg_json.get('shellcmd'),
             )
-            db_session.add(job)
+            # A job_info event may arrive for a jobid that already exists when
+            # Snakemake re-submits a failed job (e.g. via --retries). Reuse the
+            # existing row in that case so the job is not duplicated.
+            job = WorkflowJobs.query.filter(WorkflowJobs.wf_id == wf_id)\
+                .filter(WorkflowJobs.jobid == msg_json["jobid"]).first()
+            if job is not None:
+                job.restart(*job_fields)
+            else:
+                job = WorkflowJobs(msg_json['jobid'], wf_id, *job_fields)
+                db_session.add(job)
             db_session.commit()
             return True
 

--- a/panoptes/tests/server_test.py
+++ b/panoptes/tests/server_test.py
@@ -181,6 +181,38 @@ def test_job_error_flips_workflow_to_error(client):
     assert jobs["jobs"][0]["status"] == "Error"
 
 
+def test_retried_job_is_not_duplicated(client):
+    # Snakemake re-submits a failed job (e.g. --retries 1) by re-emitting a
+    # job_info event with the same jobid. The job must be updated in place, not
+    # duplicated. See https://github.com/panoptes-organization/panoptes/issues/188
+    wf_id = client.get("/create_workflow").get_json()["id"]
+
+    job_info = {
+        "level": "job_info",
+        "jobid": 7,
+        "name": "flaky_rule",
+        "input": ["a.in"],
+        "output": ["a.out"],
+        "log": ["a.log"],
+        "wildcards": {"sample": "a"},
+        "is_checkpoint": False,
+    }
+
+    # First attempt fails.
+    assert _post_event(client, wf_id, job_info).status_code == 200
+    assert _post_event(client, wf_id, {"level": "job_error", "jobid": 7}).status_code == 200
+
+    # Retry: same jobid is re-submitted and succeeds.
+    assert _post_event(client, wf_id, job_info).status_code == 200
+    assert _post_event(client, wf_id, {"level": "job_finished", "jobid": 7}).status_code == 200
+
+    jobs = client.get(f"/api/workflow/{wf_id}/jobs").get_json()
+    assert jobs["count"] == 1
+    job = jobs["jobs"][0]
+    assert job["jobid"] == 7
+    assert job["status"] == "Done"
+
+
 def test_shellcmd_message_is_stored_without_crashing(client):
     wf_id = client.get("/create_workflow").get_json()["id"]
     resp = _post_event(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (Path(__file__).parent / "README.md").read_text(encoding="utf
 
 setuptools.setup(
     name='panoptes-ui',
-    version='1.1.1',
+    version='1.1.2',
     url='https://github.com/panoptes-organization/panoptes',
     license='MIT',
     author='panoptes-organization',


### PR DESCRIPTION
## Summary

Fixes #188 — jobs were duplicated in panoptes when Snakemake ran with `--retries` and a job failed then succeeded on retry.

When Snakemake re-submits a failed job, it re-emits a `job_info` event with the **same** `jobid`. The `job_info` handler in `maintain_jobs` unconditionally inserted a new `WorkflowJobs` row, so each retry created a duplicate — one row stuck at `Error`/`Running` and another ending at `Done`, exactly as shown in the issue.

## Changes

- `panoptes/server_utilities/db_queries.py` — the `job_info` branch now looks up an existing row by `(wf_id, jobid)`; if present it updates that row in place, otherwise it inserts a new one.
- `panoptes/models.py` — new `WorkflowJobs.restart(...)` that refreshes the job's fields from the latest `job_info` and resets it to a fresh `Running` state (clears `completed_at`, updates `started_at`).
- `panoptes/tests/server_test.py` — added `test_retried_job_is_not_duplicated`.
- `setup.py` — version bump `1.1.1` → `1.1.2`.

## Testing

- Unit tests: all pass, including the new regression test.
- Manual test with a **real Snakemake 9 run** through the **real panoptes logger plugin** against a live server, using a job that fails on the first attempt and succeeds on retry (`--retries 1`):
  - **Without the fix:** `/api/workflow/1/jobs` returned `count: 4` with two `jobid=2` rows (duplicated).
  - **With the fix:** `count: 3` with a single `jobid=2` row at status `Done`.
- Verified the surviving row keeps the **latest** attempt's info (fed the retry a different `input`/`wildcards`/`shellcmd` and confirmed those values won).

🤖 Generated with [Claude Code](https://claude.com/claude-code)