### PR TITLE
Speed up CI: parallel jobs, pip cache, cached per-rule conda envs

### DIFF
--- a/.github/workflows/python-package-conda-pip.yml
+++ b/.github/workflows/python-package-conda-pip.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install panoptes + plugin + Snakemake 9
         run: |
@@ -29,9 +31,10 @@ jobs:
         run: |
           pytest panoptes/tests -v
 
+  # Runs in parallel with the unit-test matrix (no `needs:`), so the slowest
+  # job sets the wall time instead of the two adding up (#135).
   example-workflow:
     runs-on: ubuntu-latest
-    needs: test
     defaults:
       run:
         shell: bash -el {0}
@@ -39,10 +42,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clone the example workflow
+        # Cloned inside the workspace so hashFiles() below can key the cache
+        # on the per-rule conda env definitions.
+        run: |
+          git clone --depth 1 \
+            https://github.com/panoptes-organization/snakemake_example_workflow.git \
+            example_workflow
+
+      - name: Cache the per-rule conda envs
+        # Building the rule envs (samtools, htseq, coreutils) is what actually
+        # costs time in this job (#135); reuse them until envs/*.yaml change.
+        uses: actions/cache@v4
+        with:
+          path: example_workflow/.snakemake/conda
+          key: snakemake-conda-envs-${{ runner.os }}-${{ hashFiles('example_workflow/envs/*.yaml') }}
+
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
+          auto-update-conda: false
           channels: conda-forge,bioconda
           channel-priority: strict
           python-version: '3.11'
@@ -65,14 +84,8 @@ jobs:
             sleep 0.5
           done
 
-      - name: Clone the example workflow
-        run: |
-          git clone --depth 1 \
-            https://github.com/panoptes-organization/snakemake_example_workflow.git \
-            ../snakemake_example_workflow
-
       - name: Run example workflow with --logger panoptes
-        working-directory: ../snakemake_example_workflow
+        working-directory: example_workflow
         run: bash run_local.sh
 
       - name: Verify panoptes captured the run


### PR DESCRIPTION
Takes on #135. The conda-per-rule-env cost the issue was opened about (Travis-era) is much smaller on GitHub Actions, but the workflow still had avoidable time in it. Measured baseline (run 28721259211): unit-test matrix ~30s in parallel, then `example-workflow` **waits on it** (`needs: test`) and takes ~106s → **~2m20s wall**, with the biggest chunks being the workflow run itself (50s, mostly building the samtools/htseq/coreutils envs), Miniconda setup (29s), and uncached installs (~20s).

## Changes
1. **Parallelize** — dropped `needs: test`; the two jobs never depended on each other's artifacts, so now the slowest job sets the wall time.
2. **Cache pip** in the unit-test matrix (`setup-python` built-in cache).
3. **Cache the per-rule conda envs** (`example_workflow/.snakemake/conda`) keyed on `hashFiles('example_workflow/envs/*.yaml')` — this removes the dominant cost from every run where the env definitions didn't change. The example workflow is now cloned inside the workspace so `hashFiles()` can see its env files. Also `auto-update-conda: false`.

Expected steady state: **wall time ~halved** (≈70s), with the first run after an env-definition change paying the build once.

No version bump — CI-only, rides along with the next release per the bundling plan.

## Test plan
- [x] This PR's own CI run exercises the new workflow (first run = conda-env cache miss; measuring the cache-hit timing on a follow-up run)

Fixes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)