### PR TITLE
Publish a GHCR image on every release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,11 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)publish (e.g. v1.6.0) -- for backfilling a release that predates this workflow'
+        required: true
 
 permissions:
   contents: read
@@ -27,7 +32,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ github.event.inputs.tag || github.ref_name }}
             type=raw,value=latest
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PANOPTES_VERSION=${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@
 FROM python:3.12-slim
 
 ##### METADATA #####
+ARG PANOPTES_VERSION="development"
 LABEL base.image="python:3.12-slim"
 LABEL version="2"
 LABEL software="panoptes"
-LABEL software.version="development"
+LABEL software.version="${PANOPTES_VERSION}"
 LABEL software.description="Monitor computational workflows in real time"
 LABEL software.website="https://github.com/panoptes-organization/panoptes"
 LABEL software.documentation="https://github.com/panoptes-organization/panoptes/blob/master/README.md"
@@ -19,7 +20,7 @@ LABEL maintainer.license="MIT"
 WORKDIR /panoptes
 COPY . /panoptes
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir '.[postgres]'
 
 EXPOSE 5000
 


### PR DESCRIPTION
## Summary
- Fixes #62 — reinterprets "CD" as continuously delivering release artifacts (which panoptes already does for PyPI via `python-publish.yml`) rather than hosting a live instance, which is why this stalled in 2019 (Docker Hub/Heroku/AWS credits didn't fit a tool meant to be self-hosted next to whatever cluster needs to reach it).
- New `.github/workflows/docker-publish.yml`: builds the existing `Dockerfile` and pushes to `ghcr.io/panoptes-organization/panoptes` on every `release: published` event, tagged with the release version and `latest`. GHCR is free for public images under the org — no new external account or paid service needed.
- `Dockerfile`: installs the `postgres` extra (`.[postgres]`) so the published image matches what the README already promises about "the biocontainer" shipping `psycopg2`; takes the version as a build arg (`PANOPTES_VERSION`) instead of a hardcoded `"development"` label, so a release-tagged image carries real version metadata.

## Test plan
- [x] Verified `pip install '.[postgres]'` installs cleanly (psycopg2 2.9.12) on this Python version
- [ ] Local `docker build` was blocked by a Docker Desktop DNS issue in the dev environment (unrelated to these changes) — first real build/push will happen on GitHub's hosted runners when the next release is cut
- [ ] After merge, cut a release and confirm the image appears at `ghcr.io/panoptes-organization/panoptes` with the correct version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)